### PR TITLE
Corrected conversion from transmittance to absorbance

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -172,7 +172,7 @@ def JCAMP_calc_xsec(jcamp_dict, wavemin=None, wavemax=None, skip_nonquant=True, 
         y[y > 1.0] = 1.0
         
         ## convert to absorbance
-        y = log10(1.0 / y)
+        y = array([log10(1.0 / yval) for yval in y])
         
         jcamp_dict['absorbance'] = array(y)
     elif (jcamp_dict['yunits'].lower() == 'absorbance'):


### PR DESCRIPTION
I corrected the conversion from transmittance to absorbance from:

```
A = 1 - T
```

that was being used to:

```
A = -log10(T) = log10(1 / T)
```

based on these references:
http://en.wikipedia.org/wiki/Absorbance, or
http://books.google.com/books?id=BNqp0RO7DXcC&lpg=PP1&pg=PA27#v=onepage&q&f=false
