### PR TITLE
fixed regex for scientific notation

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -41,7 +41,7 @@ def JCAMP_reader(filename):
     y = []
     x = []
     datastart = False
-    jcamp_numbers_pattern = re.compile(r'([+-]?\d+[eE]{1}[+-]{1}\d+|[+-]?\d+\.\d*)|([+-]?\d+)')
+    jcamp_numbers_pattern = re.compile(r'([+-]?\d+[.]?\d*[eE][+-]{1}\d+|[+-]?\d+\.\d*)|([+-]?\d+)')
     re_le = re.compile(r'\(0\.{2}\d+\)')
     re_num = re.compile(r'\d+')
     for line in filehandle:


### PR DESCRIPTION
The regex in the earlier PR I submitted coudn't handle numbers of the form '2.5e+08' (where the mantissa is a decimal). This updated regex should be able to handle it.  