### PR TITLE
double whitespace xy delimiter

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -328,6 +328,7 @@ def jcamp_parse(line):
 
     datavals = []
     num = ""
+    line = line.replace('  ',' ')
     newline = list(line[:])
     offset = 0
     for (i,c) in enumerate(line):


### PR DESCRIPTION
I had the problem that my jcamp-dx files (batch conversion output from Essential FTIR®) come with a double whitespace to seperate x from y values:
`397.262  12699 17506 19750 21153 23299 23652`
which JCAMP_parse would return as 0.0:
`[397.262, 0.0, 12699.0, 17506.0, 19750.0, 21153.0, 23299.0, 23652.0]`
with my patch:
`[397.262, 12699.0, 17506.0, 19750.0, 21153.0, 23299.0, 23652.0]`
