### PR TITLE
Allow compound JCAMP-DX files with DATATYPE labels

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -115,7 +115,7 @@ def jcamp_read(filehandle):
 
             # Detect compound files
             # See table XI in http://www.jcamp-dx.org/protocols/dxir01.pdf
-            if (lhs == 'data type') and (rhs.lower() == 'link'):
+            if (lhs in {'data type', 'datatype'}) and (rhs.lower() == 'link'):
                 is_compound = True
                 jcamp_dict['children'] = []
 


### PR DESCRIPTION
Allows for compound JCAMP-DX files to be interpreted with `DATATYPE` dataset label instead of `DATA TYPE` which is the official specification (see section 11 of the [JCAMP specification](http://old.iupac.org/jcamp/protocols/dxir01.pdf))
(`DATATYPE` is used for example for Thermo Fisher spectrometer software)