### PR TITLE
Added bibtex file for citation

### DIFF
--- a/citation.bib
+++ b/citation.bib
@@ -1,0 +1,9 @@
+ @misc{nzhagen_2013,
+ 	title={NZHAGEN/jcamp: A set of python utilities for reading JCAMP-DX files.},
+	url={https://github.com/nzhagen/jcamp},
+	publisher={GitHub},
+	journal={Github repository},
+	author={Nzhagen},
+	year={2013},
+	month={Jul}
+}


### PR DESCRIPTION
I am writing a research paper and I'm using your package. I used this bibtex entry to cite it in my paper and I thought I'd add it for the future in case anyone else wants to cite it.

Adding this file adds a "Cite this repository" button on github so that anyone can just cite it with one click.