### PR TITLE
Reduce requirements

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -3,7 +3,6 @@
 
 from numpy import array, linspace, append, arange, logical_not, log10, nan
 import re
-from six import string_types
 import pdb
 
 '''
@@ -340,7 +339,7 @@ def is_float(s):
     '''
 
     if isinstance(s,tuple) or isinstance(s,list):
-        if not all(isinstance(i, string_types) for i in s):
+        if not all(isinstance(i, str) for i in s):
             raise TypeError("Input {} is not a list of strings".format(s))
         if (len(s) == 0):
             raise ValueError('Input {} is empty'.format(s))

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     url="https://github.com/nzhagen/jcamp",
     download_url="https://github.com/nzhagen/jcamp",
     install_requires=[
-        'matplotlib',
         'numpy',
     ],
     test_suite='tests',

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,10 @@ setup(
     author_email="nhagen@optics.arizona.edu",
     url="https://github.com/nzhagen/jcamp",
     download_url="https://github.com/nzhagen/jcamp",
-    install_requires=['numpy','six','matplotlib'],
+    install_requires=[
+        'matplotlib',
+        'numpy',
+    ],
     test_suite='tests',
     tests_require=['tox', 'coverage'],
     keywords=["jcamp", "jcamp-dx", "spectra"],


### PR DESCRIPTION
Currently `jcamp` requires `numpy`, `six` and `matplotlib`.
But the`six` requirement can be easily removed (Python2 is gone for good) and `matplotlib´ is used in demonstration code only.
Thus both packages do not need to be installed by jcamp users.