### PR TITLE
Add `jcamp.__version__` and document hints for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to `jcamp`
+
+
+## Submit a patch / proposal
+
+Your contributions and hints are welcome!
+
+Please [open an issue](https://github.com/nzhagen/jcamp/issues) if you want to discuss problems
+or discuss improvements.
+
+You code contributions are welcome, too.
+*Pull requests* via github are the preferred approach for these.
+Please take a look at the
+[github documentation](https://docs.github.com/en/get-started/quickstart/contributing-to-projects)
+if you are new to this platform.
+
+
+## Publish a new release
+
+1. update `__version__` in `jcamp.py`
+1. update `version` in `setup.py`
+1. create a release commit: `git commit -m "Release v0.1.2" jcamp.py setup.py`
+1. attach a tag to the release commit: `git tag v0.1.2`
+1. push the commit and its tag: `git push --follow-tags`
+1. publish the release to [PyPI](https://pypi.org/) (TODO: describe the procedure)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ data_dict = jcamp_read(content)
 ```
 
 
+## Contributing
+
+Your contributions and hints are welcome.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
+
+
 ## License
 
 `jcamp` is licensed under the MIT License - see the [LICENSE.txt](./LICENSE.txt) file for details

--- a/jcamp.py
+++ b/jcamp.py
@@ -18,6 +18,7 @@ __authors__ = 'Nathan Hagen'
 __license__ = 'MIT/X11 License'
 __contact__ = 'Nathan Hagen <and.the.light.shattered@gmail.com>'
 __all__     = ['jcamp_readfile', 'jcamp_calc_xsec', 'is_float', 'get_value', 'jcamp_parse']
+__version__ = '1.2.1'
 
 ## In SQZ_digits, '+' or '-' is for PAC, ',' for CSV.
 SQZ_digits = {'@':'+0', 'A':'+1', 'B':'+2', 'C':'+3', 'D':'+4', 'E':'+5', 'F':'+6', 'G':'+7', 'H':'+8', 'I':'+9',


### PR DESCRIPTION
For various reasons it is helpful to offer a version string in order to let users work around incompatible changes (e.g. the recent renaming of `JCAMP_*` to `jcamp_*`.

The second commit tries to document the steps for creating a release.

Feel to free to comment on the contribution hints. These are just wild suggestions.