### PR TITLE
Set xfactor to 1 if not available in jcamp_dict

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -190,7 +190,8 @@ def jcamp_read(filehandle):
                 dx = (
                     (jcamp_dict["lastx"] - jcamp_dict["firstx"])
                     / (jcamp_dict["npoints"] - 1)
-                    / jcamp_dict["xfactor"]
+                    # If "xfactor" is not available in jcamp_dict, use 1.0 as default.
+                    / jcamp_dict.get("xfactor",1.0)
                 )
                 continue        ## data starts on next line
             elif (lhs == 'end'):

--- a/jcamp.py
+++ b/jcamp.py
@@ -191,7 +191,7 @@ def jcamp_read(filehandle):
                     (jcamp_dict["lastx"] - jcamp_dict["firstx"])
                     / (jcamp_dict["npoints"] - 1)
                     # If "xfactor" is not available in jcamp_dict, use 1.0 as default.
-                    / jcamp_dict.get("xfactor",1.0)
+                    / jcamp_dict.get("xfactor",1)
                 )
                 continue        ## data starts on next line
             elif (lhs == 'end'):


### PR DESCRIPTION
Some jdx files do not mention "XFACTOR" in the header, which leads to an error when reading such files. 

This PR contains setting "xfactor" to 1 if "xfactor" is not available in jcamp_dict. Looking forward to your comments or if you find better solutions to circumvent this problem.