### PR TITLE
Add processing numbers with decimal comma instead of decimal dot

### DIFF
--- a/jcamp.py
+++ b/jcamp.py
@@ -171,6 +171,9 @@ def jcamp_read(filehandle):
                 jcamp_dict[lhs] = int(rhs)
             elif is_float(rhs):
                 jcamp_dict[lhs] = float(rhs)
+            # processes numbers whose decimal separator is a comma and not a dot.
+            elif is_float(rhs.replace(",", ".", 1)):
+                jcamp_dict[lhs] = float(rhs.replace(",", ".", 1))
             else:
                 jcamp_dict[lhs] = rhs
 


### PR DESCRIPTION
Thank you for improving the jcamp package so far!

Some IR spectra files were created in countries where the decimal comma is used as a decimal separator, so reading the metadata such as XFIRST = 4000,53 and XLAST = 650,32 are not considered as numbers (instead of 4000.53 and 650.32).  

How about including such cases? Here is a suggestion: If this comma, which is replaced by a dot, is considered as a float, then this value is processed. 

What do you think?