### PR TITLE
Fix import in __init__.py.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from jcamp import *
+from .jcamp import *
 
 __version__ = "1.3.0"
 __author__ = 'Nathan Hagen'


### PR DESCRIPTION
This allows using this in contexts where the whole module is also being imported as "jcamp".